### PR TITLE
Append tree size to root

### DIFF
--- a/src/mmr.cairo
+++ b/src/mmr.cairo
@@ -47,6 +47,16 @@ func bag_peaks{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
 }
 
 @view
+func compute_root{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    peaks_len: felt, peaks: felt*, size: felt
+) -> (res: felt) {
+    let (bagged_peaks) = bag_peaks(peaks_len, peaks);
+    let (root) = hash2{hash_ptr=pedersen_ptr}(size, bagged_peaks);
+
+    return (res=root);
+}
+
+@view
 func height{range_check_ptr}(index: felt) -> (res: felt) {
     alloc_locals;
 
@@ -143,7 +153,7 @@ func verify_proof{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_pt
 
     let (hash) = hash2{hash_ptr=pedersen_ptr}(index, value);
 
-    let (peak) = verify_proof_rec(0, hash, index, proof_len, proof); 
+    let (peak) = verify_proof_rec(0, hash, index, proof_len, proof);
     let (valid) = array_contains(peak, peaks_len, peaks);
 
     assert valid = 1;
@@ -190,5 +200,5 @@ func verify_proof_rec{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_chec
         tempvar range_check_ptr = range_check_ptr;
     }
 
-    return verify_proof_rec(h + 1, new_hash, new_pos, proof_len-1, proof+1);
+    return verify_proof_rec(h + 1, new_hash, new_pos, proof_len - 1, proof + 1);
 }

--- a/tests/test_append.cairo
+++ b/tests/test_append.cairo
@@ -16,7 +16,9 @@ func test_append_initial{syscall_ptr: felt*, range_check_ptr, pedersen_ptr: Hash
     let (last_pos) = get_last_pos();
     let (root) = get_root();
     assert last_pos = 1;
-    assert root = node;
+
+    let (computed_root) = hash2{hash_ptr=pedersen_ptr}(1, node);
+    assert root = computed_root;
 
     return ();
 }
@@ -43,7 +45,8 @@ func test_append_1{syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashBuilti
     let (node3) = hash2{hash_ptr=pedersen_ptr}(3, node3_1);
 
     let (root) = get_root();
-    assert root = node3;
+    let (computed_root) = hash2{hash_ptr=pedersen_ptr}(3, node3);
+    assert root = computed_root;
 
     return ();
 }
@@ -75,10 +78,11 @@ func test_append_2{syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashBuilti
     assert last_pos = 4;
 
     let (node4) = hash2{hash_ptr=pedersen_ptr}(4, 4);
-    let (root_hash) = hash2{hash_ptr=pedersen_ptr}(node3, node4);
+    let (computed_root0) = hash2{hash_ptr=pedersen_ptr}(node3, node4);
+    let (computed_root) = hash2{hash_ptr=pedersen_ptr}(4, computed_root0);
 
     let (root) = get_root();
-    assert root = root_hash;
+    assert root = computed_root;
 
     return ();
 }
@@ -121,7 +125,8 @@ func test_append_3{syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashBuilti
     let (node7) = hash2{hash_ptr=pedersen_ptr}(7, node7_1);
 
     let (root) = get_root();
-    assert root = node7;
+    let (computed_root) = hash2{hash_ptr=pedersen_ptr}(7, node7);
+    assert root = computed_root;
 
     return ();
 }
@@ -169,10 +174,11 @@ func test_append_4{syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashBuilti
     assert last_pos = 8;
 
     let (node8) = hash2{hash_ptr=pedersen_ptr}(8, 8);
-    let (root_hash) = hash2{hash_ptr=pedersen_ptr}(node7, node8);
+    let (computed_root0) = hash2{hash_ptr=pedersen_ptr}(node7, node8);
+    let (computed_root) = hash2{hash_ptr=pedersen_ptr}(8, computed_root0);
 
     let (root) = get_root();
-    assert root = root_hash;
+    assert root = computed_root;
 
     return ();
 }

--- a/tests/test_compute_root.cairo
+++ b/tests/test_compute_root.cairo
@@ -1,0 +1,75 @@
+%lang starknet
+from src.mmr import compute_root
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.hash import hash2
+
+@external
+func test_compute_root_empty{syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashBuiltin*}() {
+    alloc_locals;
+
+    let (local peaks: felt*) = alloc();
+
+    %{ expect_revert() %}
+    compute_root(0, peaks, 0);
+    return ();
+}
+
+@external
+func test_compute_root_1{syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashBuiltin*}() {
+    alloc_locals;
+
+    let (local peaks: felt*) = alloc();
+
+    let (peak0) = hash2{hash_ptr=pedersen_ptr}(1, 1);
+    assert peaks[0] = peak0;
+
+    let (root) = hash2{hash_ptr=pedersen_ptr}(1, peak0);
+
+    let (res) = compute_root(1, peaks, 1);
+    assert res = root;
+    return ();
+}
+
+@external
+func test_compute_root_2{syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashBuiltin*}() {
+    alloc_locals;
+
+    let (local peaks: felt*) = alloc();
+
+    let (peak0) = hash2{hash_ptr=pedersen_ptr}(1, 843984);
+    let (peak1) = hash2{hash_ptr=pedersen_ptr}(7, 38474983);
+
+    assert peaks[0] = peak0;
+    assert peaks[1] = peak1;
+
+    let (root0) = hash2{hash_ptr=pedersen_ptr}(peak0, peak1);
+    let (root) = hash2{hash_ptr=pedersen_ptr}(7, root0);
+
+    let (res) = compute_root(2, peaks, 7);
+    assert res = root;
+    return ();
+}
+
+@external
+func test_compute_root_3{syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashBuiltin*}() {
+    alloc_locals;
+
+    let (local peaks: felt*) = alloc();
+
+    let (peak0) = hash2{hash_ptr=pedersen_ptr}(245, 2480);
+    let (peak1) = hash2{hash_ptr=pedersen_ptr}(2340, 23428);
+    let (peak2) = hash2{hash_ptr=pedersen_ptr}(923048, 283409);
+
+    assert peaks[0] = peak0;
+    assert peaks[1] = peak1;
+    assert peaks[2] = peak2;
+
+    let (root0) = hash2{hash_ptr=pedersen_ptr}(peak1, peak2);
+    let (root1) = hash2{hash_ptr=pedersen_ptr}(peak0, root0);
+    let (root) = hash2{hash_ptr=pedersen_ptr}(923048, root1);
+
+    let (res) = compute_root(3, peaks, 923048);
+    assert res = root;
+    return ();
+}

--- a/tests/test_helpers.cairo
+++ b/tests/test_helpers.cairo
@@ -61,7 +61,8 @@ func test_all_ones{syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashBuilti
 }
 
 @external
-func test_array_contains_negative{syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashBuiltin*}() {
+func test_array_contains_negative{syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashBuiltin*}(
+    ) {
     alloc_locals;
 
     let (local arr) = alloc();

--- a/tests/test_verify_proof.cairo
+++ b/tests/test_verify_proof.cairo
@@ -135,7 +135,7 @@ func test_verify_proof_4_leaves{syscall_ptr: felt*, range_check_ptr, pedersen_pt
     assert proof[0] = node5;
     assert proof[1] = node3;
     verify_proof(4, 4, 2, proof, 1, peaks);
-    
+
     let (local proof: felt*) = alloc();
     assert proof[0] = node4;
     assert proof[1] = node3;
@@ -195,7 +195,7 @@ func test_verify_proof_5_leaves{syscall_ptr: felt*, range_check_ptr, pedersen_pt
     assert proof[0] = node5;
     assert proof[1] = node3;
     verify_proof(4, 4, 2, proof, 2, peaks);
-    
+
     let (local proof: felt*) = alloc();
     assert proof[0] = node4;
     assert proof[1] = node3;
@@ -208,7 +208,9 @@ func test_verify_proof_5_leaves{syscall_ptr: felt*, range_check_ptr, pedersen_pt
 }
 
 @external
-func test_verify_proof_invalid_index{syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashBuiltin*}() {
+func test_verify_proof_invalid_index{
+    syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashBuiltin*
+}() {
     alloc_locals;
 
     let (local peaks: felt*) = alloc();
@@ -232,7 +234,9 @@ func test_verify_proof_invalid_index{syscall_ptr: felt*, range_check_ptr, peders
 }
 
 @external
-func test_verify_proof_invalid_peaks{syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashBuiltin*}() {
+func test_verify_proof_invalid_peaks{
+    syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashBuiltin*
+}() {
     alloc_locals;
 
     let (local peaks: felt*) = alloc();
@@ -259,7 +263,9 @@ func test_verify_proof_invalid_peaks{syscall_ptr: felt*, range_check_ptr, peders
 }
 
 @external
-func test_verify_proof_invalid_proof{syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashBuiltin*}() {
+func test_verify_proof_invalid_proof{
+    syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashBuiltin*
+}() {
     alloc_locals;
 
     let (local peaks: felt*) = alloc();


### PR DESCRIPTION
The root hash now includes the total size of the tree (corresponding to `_last_pos`).

The size gets hashed together with the "bagged peaks" to get the root: `root = pedersen(tree_size, bagged_peaks)`.