### PR TITLE
Upgrade protostar to v0.8.1 and implement historical roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,28 @@
 # cairo-mmr
+
 An implementation of Merkle Mountain Ranges in cairo, using Pedersen hash. Should be used alongside an off-chain implmentation, keeping track of all the node hashes, to generate the proofs and compute the peaks
 
 > ⚠️ This repository contains a work in progress and should not be viewed as production-ready
 
 ## Set Up
+
 You should have [Protostar](https://docs.swmansion.com/protostar/) installed. See [installation](https://docs.swmansion.com/protostar/docs/tutorials/installation) docs.
 
 ### Project initialization
+
 ```bash
 protostar init <your-project-name>
 cd <your-project-name>
 ```
 
 ### Installing the library
+
 ```bash
 protostar install HerodotusDev/cairo-mmr
 ```
 
 ## Usage
+
 ```cairo
 // src/main.cairo
 
@@ -27,18 +32,17 @@ from cairo_mmr.src.mmr import append, verify_proof
 
 For demonstration purposes, in the next example we are going to keep track of the hashes and peaks on-chain. An off-chain solution should be used instead
 
-
 ```cairo
 func demo{syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashBuiltin*}() {
     alloc_locals;
 
     let (local peaks: felt*) = alloc();
-    
+
     append(elem=1, peaks_len=0, peaks=peaks);
 
     let (node1) = hash2{hash_ptr=pedersen_ptr}(1, 1);
     assert peaks[0] = node1;
-    
+
     append(elem=2, peaks_len=1, peaks=peaks);
 
     let (node2) = hash2{hash_ptr=pedersen_ptr}(2, 2);
@@ -60,23 +64,38 @@ func demo{syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashBuiltin*}() {
 }
 ```
 
+## Historical MMR
+
+Sometimes you might need to verify "immutable proofs", i.e. proofs that remains valid even when the top root hash of the tree gets updated.
+
+For that purpose, you can use the historical_mmr tree, it tracks every root hash and allows you to generate/verify proofs against it (you can check `tests/historical/*` to see some examples).
+
+```cairo
+%lang starknet
+from cairo_mmr.src.historical_mmr import append, verify_past_proof, get_inclusion_tx_hash_to_root
+```
+
 ## Development
 
 ### Project set up
+
 ```bash
 git clone git@github.com:HerodotusDev/cairo-mmr.git
 cd cairo-mmr
 ```
 
 ### Compile
+
 ```bash
 protostar build
 ```
 
 ### Test
+
 ```bash
-protostar test tests/
+protostar test
 ```
 
 ## License
+
 [GNU GPLv3](https://github.com/HerodotusDev/cairo-mmr/blob/main/LICENSE)

--- a/protostar.toml
+++ b/protostar.toml
@@ -1,8 +1,10 @@
 [project]
-protostar-version = "0.7.0"
+protostar-version = "0.8.1"
 lib-path = "lib"
+
+cairo-path = ["tests"]
 
 [contracts]
 mmr = ["src/mmr.cairo"]
+historical_mmr = ["src/historical_mmr.cairo"]
 helpers = ["src/helpers.cairo"]
-

--- a/src/historical_mmr.cairo
+++ b/src/historical_mmr.cairo
@@ -1,0 +1,244 @@
+%lang starknet
+from starkware.cairo.common.hash import hash2
+from starkware.cairo.common.math import assert_le, assert_nn_le, assert_nn
+from starkware.cairo.common.math_cmp import is_le
+from starkware.cairo.common.memcpy import memcpy
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+
+from src.helpers import bit_length, all_ones, bitshift_left, array_contains
+
+@storage_var
+func _root() -> (res: felt) {
+}
+
+@storage_var
+func _last_pos() -> (res: felt) {
+}
+
+@storage_var
+func _inclusion_tx_hash_to_root(tx_hash: felt) -> (res: felt) {
+}
+
+@view
+func get_root{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (res: felt) {
+    return _root.read();
+}
+
+@view
+func get_last_pos{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    res: felt
+) {
+    return _last_pos.read();
+}
+
+@view
+func get_inclusion_tx_hash_to_root{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    tx_hash: felt
+) -> (res: felt) {
+    return _inclusion_tx_hash_to_root.read(tx_hash);
+}
+
+@view
+func bag_peaks{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    peaks_len: felt, peaks: felt*
+) -> (res: felt) {
+    assert_le(1, peaks_len);
+
+    if (peaks_len == 1) {
+        return (res=[peaks]);
+    }
+
+    let last_peak = [peaks];
+    let (rec) = bag_peaks(peaks_len - 1, peaks + 1);
+
+    let (res) = hash2{hash_ptr=pedersen_ptr}(last_peak, rec);
+
+    return (res=res);
+}
+
+@view
+func compute_root{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    peaks_len: felt, peaks: felt*, size: felt
+) -> (res: felt) {
+    let (bagged_peaks) = bag_peaks(peaks_len, peaks);
+    let (root) = hash2{hash_ptr=pedersen_ptr}(size, bagged_peaks);
+
+    return (res=root);
+}
+
+@view
+func height{range_check_ptr}(index: felt) -> (res: felt) {
+    alloc_locals;
+
+    assert_le(1, index);
+
+    let (bits) = bit_length(index);
+    let (ones) = all_ones(bits);
+    if (index != ones) {
+        let (shifted) = bitshift_left(1, bits - 1);
+        let (rec_height) = height(index - (shifted - 1));
+        return (res=rec_height);
+    }
+
+    return (res=bits - 1);
+}
+
+@external
+func append{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    elem: felt, peaks_len: felt, peaks: felt*, tx_hash: felt
+) -> (pos: felt) {
+    alloc_locals;
+
+    let (pos) = _last_pos.read();
+    _last_pos.write(pos + 1);
+
+    if (pos == 0) {
+        let (root0) = hash2{hash_ptr=pedersen_ptr}(1, elem);
+        let (root) = hash2{hash_ptr=pedersen_ptr}(1, root0);
+        _inclusion_tx_hash_to_root.write(tx_hash, root);
+        _root.write(root);
+        return (pos=1);
+    }
+
+    let (computed_root) = compute_root(peaks_len, peaks, pos);
+    let (root) = _root.read();
+    assert computed_root = root;
+
+    let (current_pos) = _last_pos.read();
+    let (hash) = hash2{hash_ptr=pedersen_ptr}(current_pos, elem);
+
+    let (local append_peak) = alloc();
+    memcpy(append_peak, peaks, peaks_len);
+    assert append_peak[peaks_len] = hash;
+
+    let (peaks_len, peaks) = append_rec(0, peaks_len + 1, append_peak);
+
+    let (new_pos) = _last_pos.read();
+    let (new_root) = compute_root(peaks_len, peaks, new_pos);
+    _inclusion_tx_hash_to_root.write(tx_hash, new_root);
+    _root.write(new_root);
+
+    return (pos=new_pos);
+}
+
+func append_rec{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    h: felt, peaks_len: felt, peaks: felt*
+) -> (p_len: felt, p: felt*) {
+    alloc_locals;
+
+    let (pos) = _last_pos.read();
+    let (next_height) = height(pos + 1);
+
+    let is_higher = is_le(h + 1, next_height);
+    if (is_higher == 1) {
+        _last_pos.write(pos + 1);
+
+        let right_hash = peaks[peaks_len - 1];
+        let left_hash = peaks[peaks_len - 2];
+        let peaks_len = peaks_len - 2;
+
+        let (hash) = hash2{hash_ptr=pedersen_ptr}(left_hash, right_hash);
+
+        let (current_pos) = _last_pos.read();
+        let (parent_hash) = hash2{hash_ptr=pedersen_ptr}(current_pos, hash);
+
+        let (local merged_peaks) = alloc();
+        memcpy(merged_peaks, peaks, peaks_len);
+        assert merged_peaks[peaks_len] = parent_hash;
+
+        return append_rec(h + 1, peaks_len + 1, merged_peaks);
+    }
+
+    return (p_len=peaks_len, p=peaks);
+}
+
+@view
+func verify_past_proof{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    index: felt,
+    value: felt,
+    proof_len: felt,
+    proof: felt*,
+    peaks_len: felt,
+    peaks: felt*,
+    inclusion_tx_hash: felt,
+    pos: felt,
+) {
+    alloc_locals;
+    let (computed_root) = compute_root(peaks_len, peaks, pos);
+    let (root) = _inclusion_tx_hash_to_root.read(inclusion_tx_hash);
+    assert computed_root = root;
+
+    let (hash) = hash2{hash_ptr=pedersen_ptr}(index, value);
+
+    let (peak) = verify_proof_rec(0, hash, index, proof_len, proof);
+    let (valid) = array_contains(peak, peaks_len, peaks);
+
+    assert valid = 1;
+    return ();
+}
+
+@view
+func verify_proof{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    index: felt, value: felt, proof_len: felt, proof: felt*, peaks_len: felt, peaks: felt*
+) {
+    alloc_locals;
+
+    let (pos) = _last_pos.read();
+    assert_nn_le(index, pos);
+
+    let (computed_root) = compute_root(peaks_len, peaks, pos);
+    let (root) = _root.read();
+    assert computed_root = root;
+
+    let (hash) = hash2{hash_ptr=pedersen_ptr}(index, value);
+
+    let (peak) = verify_proof_rec(0, hash, index, proof_len, proof);
+    let (valid) = array_contains(peak, peaks_len, peaks);
+
+    assert valid = 1;
+    return ();
+}
+
+func verify_proof_rec{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    h: felt, hash: felt, pos: felt, proof_len: felt, proof: felt*
+) -> (res: felt) {
+    alloc_locals;
+
+    if (proof_len == 0) {
+        return (res=hash);
+    }
+
+    let current_sibling = [proof];
+    let (current_height) = height(pos);
+    let (next_height) = height(pos + 1);
+
+    let is_higher = is_le(h + 1, next_height);
+
+    local new_hash;
+    local new_pos;
+    if (is_higher == 1) {
+        // right child
+        let (hashed) = hash2{hash_ptr=pedersen_ptr}(current_sibling, hash);
+        new_pos = pos + 1;
+
+        let (parent_hash) = hash2{hash_ptr=pedersen_ptr}(new_pos, hashed);
+        new_hash = parent_hash;
+
+        tempvar pedersen_ptr = pedersen_ptr;
+        tempvar range_check_ptr = range_check_ptr;
+    } else {
+        // left child
+        let (hashed) = hash2{hash_ptr=pedersen_ptr}(hash, current_sibling);
+        let (shifted) = bitshift_left(2, h);
+        new_pos = pos + shifted;
+
+        let (parent_hash) = hash2{hash_ptr=pedersen_ptr}(new_pos, hashed);
+        new_hash = parent_hash;
+
+        tempvar pedersen_ptr = pedersen_ptr;
+        tempvar range_check_ptr = range_check_ptr;
+    }
+
+    return verify_proof_rec(h + 1, new_hash, new_pos, proof_len - 1, proof + 1);
+}

--- a/tests/historical/test_append.cairo
+++ b/tests/historical/test_append.cairo
@@ -1,0 +1,191 @@
+%lang starknet
+from src.historical_mmr import append, get_root, get_last_pos, get_inclusion_tx_hash_to_root
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.hash import hash2
+from starkware.cairo.common.alloc import alloc
+
+@external
+func test_append_initial{syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashBuiltin*}() {
+    alloc_locals;
+
+    let (local peaks: felt*) = alloc();
+
+    append(elem=1, peaks_len=0, peaks=peaks, tx_hash=123);
+    let (node) = hash2{hash_ptr=pedersen_ptr}(1, 1);
+
+    let (last_pos) = get_last_pos();
+    let (root) = get_root();
+    assert last_pos = 1;
+
+    let (computed_root) = hash2{hash_ptr=pedersen_ptr}(1, node);
+    assert root = computed_root;
+
+    return ();
+}
+
+@external
+func test_append_1{syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashBuiltin*}() {
+    alloc_locals;
+
+    let (local peaks: felt*) = alloc();
+
+    let (last_pos) = get_last_pos();
+
+    let (node1) = hash2{hash_ptr=pedersen_ptr}(1, 1);
+    append(elem=1, peaks_len=0, peaks=peaks, tx_hash=123);
+
+    assert peaks[0] = node1;
+    append(elem=2, peaks_len=1, peaks=peaks, tx_hash=123);
+
+    let (last_pos) = get_last_pos();
+    assert last_pos = 3;
+
+    let (node2) = hash2{hash_ptr=pedersen_ptr}(2, 2);
+    let (node3_1) = hash2{hash_ptr=pedersen_ptr}(node1, node2);
+    let (node3) = hash2{hash_ptr=pedersen_ptr}(3, node3_1);
+
+    let (root) = get_root();
+    let (computed_root) = hash2{hash_ptr=pedersen_ptr}(3, node3);
+    assert root = computed_root;
+    let (tx_hash_root) = get_inclusion_tx_hash_to_root(tx_hash=123);
+    assert tx_hash_root = root;
+
+    return ();
+}
+
+@external
+func test_append_2{syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashBuiltin*}() {
+    alloc_locals;
+
+    let (local peaks: felt*) = alloc();
+
+    let (last_pos) = get_last_pos();
+
+    let (node1) = hash2{hash_ptr=pedersen_ptr}(1, 1);
+    append(elem=1, peaks_len=0, peaks=peaks, tx_hash=456);
+
+    assert peaks[0] = node1;
+    append(elem=2, peaks_len=1, peaks=peaks, tx_hash=456);
+
+    let (node2) = hash2{hash_ptr=pedersen_ptr}(2, 2);
+    let (node3_1) = hash2{hash_ptr=pedersen_ptr}(node1, node2);
+    let (node3) = hash2{hash_ptr=pedersen_ptr}(3, node3_1);
+
+    let (local peaks: felt*) = alloc();
+
+    assert peaks[0] = node3;
+    append(elem=4, peaks_len=1, peaks=peaks, tx_hash=456);
+
+    let (last_pos) = get_last_pos();
+    assert last_pos = 4;
+
+    let (node4) = hash2{hash_ptr=pedersen_ptr}(4, 4);
+    let (computed_root0) = hash2{hash_ptr=pedersen_ptr}(node3, node4);
+    let (computed_root) = hash2{hash_ptr=pedersen_ptr}(4, computed_root0);
+
+    let (root) = get_root();
+    assert root = computed_root;
+    let (tx_hash_root) = get_inclusion_tx_hash_to_root(tx_hash=456);
+    assert tx_hash_root = root;
+
+    return ();
+}
+
+@external
+func test_append_3{syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashBuiltin*}() {
+    alloc_locals;
+
+    let (local peaks: felt*) = alloc();
+
+    let (last_pos) = get_last_pos();
+
+    let (node1) = hash2{hash_ptr=pedersen_ptr}(1, 1);
+    append(elem=1, peaks_len=0, peaks=peaks, tx_hash=789);
+
+    assert peaks[0] = node1;
+    append(elem=2, peaks_len=1, peaks=peaks, tx_hash=789);
+
+    let (node2) = hash2{hash_ptr=pedersen_ptr}(2, 2);
+    let (node3_1) = hash2{hash_ptr=pedersen_ptr}(node1, node2);
+    let (node3) = hash2{hash_ptr=pedersen_ptr}(3, node3_1);
+
+    let (local peaks: felt*) = alloc();
+
+    assert peaks[0] = node3;
+    append(elem=4, peaks_len=1, peaks=peaks, tx_hash=789);
+
+    let (node4) = hash2{hash_ptr=pedersen_ptr}(4, 4);
+    assert peaks[1] = node4;
+
+    append(elem=5, peaks_len=2, peaks=peaks, tx_hash=789);
+
+    let (last_pos) = get_last_pos();
+    assert last_pos = 7;
+
+    let (node5) = hash2{hash_ptr=pedersen_ptr}(5, 5);
+    let (node6_1) = hash2{hash_ptr=pedersen_ptr}(node4, node5);
+    let (node6) = hash2{hash_ptr=pedersen_ptr}(6, node6_1);
+    let (node7_1) = hash2{hash_ptr=pedersen_ptr}(node3, node6);
+    let (node7) = hash2{hash_ptr=pedersen_ptr}(7, node7_1);
+
+    let (root) = get_root();
+    let (computed_root) = hash2{hash_ptr=pedersen_ptr}(7, node7);
+    assert root = computed_root;
+    let (tx_hash_root) = get_inclusion_tx_hash_to_root(tx_hash=789);
+    assert tx_hash_root = root;
+
+    return ();
+}
+
+@external
+func test_append_4{syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashBuiltin*}() {
+    alloc_locals;
+
+    let (local peaks: felt*) = alloc();
+
+    let (last_pos) = get_last_pos();
+
+    let (node1) = hash2{hash_ptr=pedersen_ptr}(1, 1);
+    append(elem=1, peaks_len=0, peaks=peaks, tx_hash=101112);
+
+    assert peaks[0] = node1;
+    append(elem=2, peaks_len=1, peaks=peaks, tx_hash=101112);
+
+    let (node2) = hash2{hash_ptr=pedersen_ptr}(2, 2);
+    let (node3_1) = hash2{hash_ptr=pedersen_ptr}(node1, node2);
+    let (node3) = hash2{hash_ptr=pedersen_ptr}(3, node3_1);
+
+    let (local peaks: felt*) = alloc();
+
+    assert peaks[0] = node3;
+    append(elem=4, peaks_len=1, peaks=peaks, tx_hash=101112);
+
+    let (node4) = hash2{hash_ptr=pedersen_ptr}(4, 4);
+    assert peaks[1] = node4;
+
+    append(elem=5, peaks_len=2, peaks=peaks, tx_hash=101112);
+
+    let (node5) = hash2{hash_ptr=pedersen_ptr}(5, 5);
+    let (node6_1) = hash2{hash_ptr=pedersen_ptr}(node4, node5);
+    let (node6) = hash2{hash_ptr=pedersen_ptr}(6, node6_1);
+    let (node7_1) = hash2{hash_ptr=pedersen_ptr}(node3, node6);
+    let (node7) = hash2{hash_ptr=pedersen_ptr}(7, node7_1);
+
+    let (local peaks: felt*) = alloc();
+
+    assert peaks[0] = node7;
+    append(elem=8, peaks_len=1, peaks=peaks, tx_hash=101112);
+
+    let (last_pos) = get_last_pos();
+    assert last_pos = 8;
+
+    let (node8) = hash2{hash_ptr=pedersen_ptr}(8, 8);
+    let (computed_root0) = hash2{hash_ptr=pedersen_ptr}(node7, node8);
+    let (computed_root) = hash2{hash_ptr=pedersen_ptr}(8, computed_root0);
+
+    let (root) = get_root();
+    assert root = computed_root;
+    let (tx_hash_root) = get_inclusion_tx_hash_to_root(tx_hash=101112);
+    assert tx_hash_root = root;
+    return ();
+}

--- a/tests/historical/test_verify_proof.cairo
+++ b/tests/historical/test_verify_proof.cairo
@@ -1,0 +1,476 @@
+%lang starknet
+from src.historical_mmr import append, verify_past_proof, verify_proof
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.hash import hash2
+
+@external
+func test_verify_proof_1_leaf{syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashBuiltin*}() {
+    alloc_locals;
+
+    let (local peaks: felt*) = alloc();
+
+    let (node1) = hash2{hash_ptr=pedersen_ptr}(1, 1);
+    append(elem=1, peaks_len=0, peaks=peaks, tx_hash=123);
+
+    assert peaks[0] = node1;
+
+    let (local proof: felt*) = alloc();
+    verify_proof(1, 1, 0, proof, 1, peaks);
+
+    return ();
+}
+
+@external
+func test_verify_past_proof_1_leaf{syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashBuiltin*}(
+    ) {
+    alloc_locals;
+
+    let (local peaks: felt*) = alloc();
+
+    let (node1) = hash2{hash_ptr=pedersen_ptr}(1, 1);
+    let (cur_pos: felt) = append(elem=1, peaks_len=0, peaks=peaks, tx_hash=123);
+
+    assert peaks[0] = node1;
+
+    let (local proof: felt*) = alloc();
+    verify_past_proof(1, 1, 0, proof, 1, peaks, 123, cur_pos);
+
+    return ();
+}
+
+@external
+func test_verify_past_proof_2_leaves{
+    syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashBuiltin*
+}() {
+    alloc_locals;
+
+    let (local peaks: felt*) = alloc();
+
+    let (node1) = hash2{hash_ptr=pedersen_ptr}(1, 1);
+    let (cur_pos: felt) = append(elem=1, peaks_len=0, peaks=peaks, tx_hash=456);
+
+    assert peaks[0] = node1;
+
+    let (local proof: felt*) = alloc();
+    verify_past_proof(1, 1, 0, proof, 1, peaks, 456, cur_pos);
+
+    let (cur_pos_2: felt) = append(elem=2, peaks_len=1, peaks=peaks, tx_hash=457);
+
+    let (node2) = hash2{hash_ptr=pedersen_ptr}(2, 2);
+    let (node3_1) = hash2{hash_ptr=pedersen_ptr}(node1, node2);
+    let (node3) = hash2{hash_ptr=pedersen_ptr}(3, node3_1);
+
+    let (local peaks: felt*) = alloc();
+    assert peaks[0] = node3;
+
+    let (local proof: felt*) = alloc();
+    assert proof[0] = node1;
+
+    verify_past_proof(2, 2, 1, proof, 1, peaks, 457, cur_pos_2);
+    return ();
+}
+
+@external
+func test_verify_proof_2_leaves{syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashBuiltin*}() {
+    alloc_locals;
+
+    let (local peaks: felt*) = alloc();
+
+    let (node1) = hash2{hash_ptr=pedersen_ptr}(1, 1);
+    append(elem=1, peaks_len=0, peaks=peaks, tx_hash=456);
+
+    assert peaks[0] = node1;
+    append(elem=2, peaks_len=1, peaks=peaks, tx_hash=467);
+
+    let (node2) = hash2{hash_ptr=pedersen_ptr}(2, 2);
+    let (node3_1) = hash2{hash_ptr=pedersen_ptr}(node1, node2);
+    let (node3) = hash2{hash_ptr=pedersen_ptr}(3, node3_1);
+
+    let (local peaks: felt*) = alloc();
+    assert peaks[0] = node3;
+
+    let (local proof: felt*) = alloc();
+    assert proof[0] = node2;
+    verify_proof(1, 1, 1, proof, 1, peaks);
+
+    let (local proof: felt*) = alloc();
+    assert proof[0] = node1;
+    verify_proof(2, 2, 1, proof, 1, peaks);
+
+    return ();
+}
+
+@external
+func test_verify_past_proof_3_leaves{
+    syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashBuiltin*
+}() {
+    alloc_locals;
+
+    let (node1) = hash2{hash_ptr=pedersen_ptr}(1, 1);
+    let (local peaks_1: felt*) = alloc();
+    let (last_pos_leaf_1) = append(elem=1, peaks_len=0, peaks=peaks_1, tx_hash=789);
+    let (local proof_1: felt*) = alloc();
+    assert peaks_1[0] = node1;
+
+    let (local proof_2: felt*) = alloc();
+    assert proof_2[0] = node1;
+    let (last_pos_leaf_2) = append(elem=2, peaks_len=1, peaks=peaks_1, tx_hash=7891);
+    let (node2) = hash2{hash_ptr=pedersen_ptr}(2, 2);
+    let (node3_1) = hash2{hash_ptr=pedersen_ptr}(node1, node2);
+    let (node3) = hash2{hash_ptr=pedersen_ptr}(3, node3_1);
+    let (local peaks_2: felt*) = alloc();
+    assert peaks_2[0] = node3;
+
+    let (last_pos_leaf_3) = append(elem=4, peaks_len=1, peaks=peaks_2, tx_hash=7892);
+    let (local proof_3: felt*) = alloc();
+    let (node4) = hash2{hash_ptr=pedersen_ptr}(4, 4);
+    assert peaks_2[1] = node4;
+
+    verify_past_proof(4, 4, 0, proof_3, 2, peaks_2, 7892, last_pos_leaf_3);
+    verify_past_proof(1, 1, 0, proof_1, 1, peaks_1, 789, last_pos_leaf_1);
+    verify_past_proof(2, 2, 1, proof_2, 1, peaks_2, 7891, last_pos_leaf_2);
+    return ();
+}
+
+@external
+func test_verify_proof_3_leaves{syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashBuiltin*}() {
+    alloc_locals;
+
+    let (local peaks: felt*) = alloc();
+
+    let (node1) = hash2{hash_ptr=pedersen_ptr}(1, 1);
+    append(elem=1, peaks_len=0, peaks=peaks, tx_hash=789);
+
+    assert peaks[0] = node1;
+    append(elem=2, peaks_len=1, peaks=peaks, tx_hash=789);
+
+    let (node2) = hash2{hash_ptr=pedersen_ptr}(2, 2);
+    let (node3_1) = hash2{hash_ptr=pedersen_ptr}(node1, node2);
+    let (node3) = hash2{hash_ptr=pedersen_ptr}(3, node3_1);
+
+    let (local peaks: felt*) = alloc();
+    assert peaks[0] = node3;
+    append(elem=4, peaks_len=1, peaks=peaks, tx_hash=789);
+
+    let (node4) = hash2{hash_ptr=pedersen_ptr}(4, 4);
+    assert peaks[1] = node4;
+
+    let (local proof: felt*) = alloc();
+    assert proof[0] = node2;
+    verify_proof(1, 1, 1, proof, 2, peaks);
+
+    let (local proof: felt*) = alloc();
+    assert proof[0] = node1;
+    verify_proof(2, 2, 1, proof, 2, peaks);
+
+    let (local proof: felt*) = alloc();
+    verify_proof(4, 4, 0, proof, 2, peaks);
+
+    return ();
+}
+
+@external
+func test_verify_past_proof_4_leaves{
+    syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashBuiltin*
+}() {
+    alloc_locals;
+
+    let (local peaks: felt*) = alloc();
+
+    let (node1) = hash2{hash_ptr=pedersen_ptr}(1, 1);
+    let (local peaks_1: felt*) = alloc();
+    let (last_pos_leaf_1) = append(elem=1, peaks_len=0, peaks=peaks_1, tx_hash=101112);
+    let (local proof_1: felt*) = alloc();
+    assert peaks_1[0] = node1;
+    verify_past_proof(1, 1, 0, proof_1, 1, peaks_1, 101112, last_pos_leaf_1);
+
+    let (local proof_2: felt*) = alloc();
+    assert proof_2[0] = node1;
+    let (last_pos_leaf_2) = append(elem=2, peaks_len=1, peaks=peaks_1, tx_hash=101113);
+    let (node2) = hash2{hash_ptr=pedersen_ptr}(2, 2);
+    let (node3_1) = hash2{hash_ptr=pedersen_ptr}(node1, node2);
+    let (node3) = hash2{hash_ptr=pedersen_ptr}(3, node3_1);
+    let (local peaks_2: felt*) = alloc();
+    assert peaks_2[0] = node3;
+    verify_past_proof(2, 2, 1, proof_2, 1, peaks_2, 101113, last_pos_leaf_2);
+
+    let (last_pos_leaf_3) = append(elem=4, peaks_len=1, peaks=peaks_2, tx_hash=101114);
+    let (local proof_3: felt*) = alloc();
+    let (node4) = hash2{hash_ptr=pedersen_ptr}(4, 4);
+    assert peaks_2[1] = node4;
+    verify_past_proof(4, 4, 0, proof_3, 2, peaks_2, 101114, last_pos_leaf_3);
+
+    let (node5) = hash2{hash_ptr=pedersen_ptr}(5, 5);
+    let (node6_1) = hash2{hash_ptr=pedersen_ptr}(node4, node5);
+    let (node6) = hash2{hash_ptr=pedersen_ptr}(6, node6_1);
+    let (node7_1) = hash2{hash_ptr=pedersen_ptr}(node3, node6);
+    let (node7) = hash2{hash_ptr=pedersen_ptr}(7, node7_1);
+
+    let (last_pos_leaf_4) = append(elem=5, peaks_len=2, peaks=peaks_2, tx_hash=101115);
+
+    let (local peaks_3: felt*) = alloc();
+    assert peaks_3[0] = node7;
+    let (local proof_4: felt*) = alloc();
+    assert proof_4[0] = node4;
+    assert proof_4[1] = node3;
+    verify_past_proof(5, 5, 2, proof_4, 1, peaks_3, 101115, last_pos_leaf_4);
+    return ();
+}
+
+@external
+func test_verify_proof_4_leaves{syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashBuiltin*}() {
+    alloc_locals;
+
+    let (local peaks: felt*) = alloc();
+
+    let (node1) = hash2{hash_ptr=pedersen_ptr}(1, 1);
+    append(elem=1, peaks_len=0, peaks=peaks, tx_hash=101112);
+
+    assert peaks[0] = node1;
+    append(elem=2, peaks_len=1, peaks=peaks, tx_hash=101112);
+
+    let (node2) = hash2{hash_ptr=pedersen_ptr}(2, 2);
+    let (node3_1) = hash2{hash_ptr=pedersen_ptr}(node1, node2);
+    let (node3) = hash2{hash_ptr=pedersen_ptr}(3, node3_1);
+
+    let (local peaks: felt*) = alloc();
+    assert peaks[0] = node3;
+    append(elem=4, peaks_len=1, peaks=peaks, tx_hash=101112);
+
+    let (node4) = hash2{hash_ptr=pedersen_ptr}(4, 4);
+    assert peaks[1] = node4;
+    append(elem=5, peaks_len=2, peaks=peaks, tx_hash=101112);
+
+    let (node5) = hash2{hash_ptr=pedersen_ptr}(5, 5);
+    let (node6_1) = hash2{hash_ptr=pedersen_ptr}(node4, node5);
+    let (node6) = hash2{hash_ptr=pedersen_ptr}(6, node6_1);
+    let (node7_1) = hash2{hash_ptr=pedersen_ptr}(node3, node6);
+    let (node7) = hash2{hash_ptr=pedersen_ptr}(7, node7_1);
+
+    let (local peaks: felt*) = alloc();
+    assert peaks[0] = node7;
+
+    let (local proof: felt*) = alloc();
+    assert proof[0] = node2;
+    assert proof[1] = node6;
+    verify_proof(1, 1, 2, proof, 1, peaks);
+
+    let (local proof: felt*) = alloc();
+    assert proof[0] = node1;
+    assert proof[1] = node6;
+    verify_proof(2, 2, 2, proof, 1, peaks);
+
+    let (local proof: felt*) = alloc();
+    assert proof[0] = node5;
+    assert proof[1] = node3;
+    verify_proof(4, 4, 2, proof, 1, peaks);
+
+    let (local proof: felt*) = alloc();
+    assert proof[0] = node4;
+    assert proof[1] = node3;
+    verify_proof(5, 5, 2, proof, 1, peaks);
+
+    return ();
+}
+
+@external
+func test_verify_past_proof_5_leaves{
+    syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashBuiltin*
+}() {
+    alloc_locals;
+    let (local peaks: felt*) = alloc();
+    let (node1) = hash2{hash_ptr=pedersen_ptr}(1, 1);
+    let (local peaks_1: felt*) = alloc();
+    let (last_pos_leaf_1) = append(elem=1, peaks_len=0, peaks=peaks_1, tx_hash=101112);
+    let (local proof_1: felt*) = alloc();
+    assert peaks_1[0] = node1;
+
+    let (local proof_2: felt*) = alloc();
+    assert proof_2[0] = node1;
+    let (last_pos_leaf_2) = append(elem=2, peaks_len=1, peaks=peaks_1, tx_hash=101113);
+    let (node2) = hash2{hash_ptr=pedersen_ptr}(2, 2);
+    let (node3_1) = hash2{hash_ptr=pedersen_ptr}(node1, node2);
+    let (node3) = hash2{hash_ptr=pedersen_ptr}(3, node3_1);
+    let (local peaks_2: felt*) = alloc();
+    assert peaks_2[0] = node3;
+
+    let (last_pos_leaf_3) = append(elem=4, peaks_len=1, peaks=peaks_2, tx_hash=101114);
+    let (local proof_3: felt*) = alloc();
+    let (node4) = hash2{hash_ptr=pedersen_ptr}(4, 4);
+    assert peaks_2[1] = node4;
+
+    let (node5) = hash2{hash_ptr=pedersen_ptr}(5, 5);
+    let (node6_1) = hash2{hash_ptr=pedersen_ptr}(node4, node5);
+    let (node6) = hash2{hash_ptr=pedersen_ptr}(6, node6_1);
+    let (node7_1) = hash2{hash_ptr=pedersen_ptr}(node3, node6);
+    let (node7) = hash2{hash_ptr=pedersen_ptr}(7, node7_1);
+
+    let (last_pos_leaf_4) = append(elem=5, peaks_len=2, peaks=peaks_2, tx_hash=101115);
+    let (local peaks_3: felt*) = alloc();
+    assert peaks_3[0] = node7;
+    let (local proof_4: felt*) = alloc();
+    assert proof_4[0] = node4;
+    assert proof_4[1] = node3;
+
+    let (last_pos_leaf_5) = append(elem=8, peaks_len=1, peaks=peaks_3, tx_hash=101116);
+    let (local proof_5: felt*) = alloc();
+    let (local peaks_4: felt*) = alloc();
+    assert peaks_4[0] = node7;
+    let (node8) = hash2{hash_ptr=pedersen_ptr}(8, 8);
+    assert peaks_4[1] = node8;
+
+    verify_past_proof(8, 8, 0, proof_5, 2, peaks_4, 101116, last_pos_leaf_5);
+    verify_past_proof(2, 2, 1, proof_2, 1, peaks_2, 101113, last_pos_leaf_2);
+    verify_past_proof(1, 1, 0, proof_1, 1, peaks_1, 101112, last_pos_leaf_1);
+    verify_past_proof(4, 4, 0, proof_3, 2, peaks_2, 101114, last_pos_leaf_3);
+    verify_past_proof(5, 5, 2, proof_4, 1, peaks_3, 101115, last_pos_leaf_4);
+    return ();
+}
+
+@external
+func test_verify_proof_5_leaves{syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashBuiltin*}() {
+    alloc_locals;
+
+    let (local peaks: felt*) = alloc();
+
+    let (node1) = hash2{hash_ptr=pedersen_ptr}(1, 1);
+    append(elem=1, peaks_len=0, peaks=peaks, tx_hash=111213);
+
+    assert peaks[0] = node1;
+    append(elem=2, peaks_len=1, peaks=peaks, tx_hash=111213);
+
+    let (node2) = hash2{hash_ptr=pedersen_ptr}(2, 2);
+    let (node3_1) = hash2{hash_ptr=pedersen_ptr}(node1, node2);
+    let (node3) = hash2{hash_ptr=pedersen_ptr}(3, node3_1);
+
+    let (local peaks: felt*) = alloc();
+    assert peaks[0] = node3;
+    append(elem=4, peaks_len=1, peaks=peaks, tx_hash=111213);
+
+    let (node4) = hash2{hash_ptr=pedersen_ptr}(4, 4);
+    assert peaks[1] = node4;
+    append(elem=5, peaks_len=2, peaks=peaks, tx_hash=111213);
+
+    let (node5) = hash2{hash_ptr=pedersen_ptr}(5, 5);
+    let (node6_1) = hash2{hash_ptr=pedersen_ptr}(node4, node5);
+    let (node6) = hash2{hash_ptr=pedersen_ptr}(6, node6_1);
+    let (node7_1) = hash2{hash_ptr=pedersen_ptr}(node3, node6);
+    let (node7) = hash2{hash_ptr=pedersen_ptr}(7, node7_1);
+
+    let (local peaks: felt*) = alloc();
+    assert peaks[0] = node7;
+    append(elem=8, peaks_len=1, peaks=peaks, tx_hash=111213);
+
+    let (node8) = hash2{hash_ptr=pedersen_ptr}(8, 8);
+    assert peaks[1] = node8;
+
+    let (local proof: felt*) = alloc();
+    assert proof[0] = node2;
+    assert proof[1] = node6;
+    verify_proof(1, 1, 2, proof, 2, peaks);
+
+    let (local proof: felt*) = alloc();
+    assert proof[0] = node1;
+    assert proof[1] = node6;
+    verify_proof(2, 2, 2, proof, 2, peaks);
+
+    let (local proof: felt*) = alloc();
+    assert proof[0] = node5;
+    assert proof[1] = node3;
+    verify_proof(4, 4, 2, proof, 2, peaks);
+
+    let (local proof: felt*) = alloc();
+    assert proof[0] = node4;
+    assert proof[1] = node3;
+    verify_proof(5, 5, 2, proof, 2, peaks);
+
+    let (local proof: felt*) = alloc();
+    verify_proof(8, 8, 0, proof, 2, peaks);
+
+    return ();
+}
+
+@external
+func test_verify_proof_invalid_index{
+    syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashBuiltin*
+}() {
+    alloc_locals;
+
+    let (local peaks: felt*) = alloc();
+
+    let (node1) = hash2{hash_ptr=pedersen_ptr}(1, 1);
+    append(elem=1, peaks_len=0, peaks=peaks, tx_hash=141516);
+
+    let (node2) = hash2{hash_ptr=pedersen_ptr}(2, 2);
+    let (node3_1) = hash2{hash_ptr=pedersen_ptr}(node1, node2);
+    let (node3) = hash2{hash_ptr=pedersen_ptr}(3, node3_1);
+
+    let (local peaks: felt*) = alloc();
+    assert peaks[0] = node3;
+
+    let (local proof: felt*) = alloc();
+    assert proof[0] = node1;
+    %{ expect_revert() %}
+    verify_proof(2, 2, 1, proof, 1, peaks);
+
+    return ();
+}
+
+@external
+func test_verify_proof_invalid_peaks{
+    syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashBuiltin*
+}() {
+    alloc_locals;
+
+    let (local peaks: felt*) = alloc();
+
+    let (node1) = hash2{hash_ptr=pedersen_ptr}(1, 1);
+    append(elem=1, peaks_len=0, peaks=peaks, tx_hash=161718);
+
+    assert peaks[0] = node1;
+    append(elem=2, peaks_len=1, peaks=peaks, tx_hash=161718);
+
+    let (node2) = hash2{hash_ptr=pedersen_ptr}(2, 2);
+    let (node3_1) = hash2{hash_ptr=pedersen_ptr}(node1, node2);
+    let (node3) = hash2{hash_ptr=pedersen_ptr}(3, node3_1);
+
+    let (local peaks: felt*) = alloc();
+    assert peaks[0] = node1;
+
+    let (local proof: felt*) = alloc();
+    assert proof[0] = node2;
+    %{ expect_revert() %}
+    verify_proof(1, 1, 1, proof, 1, peaks);
+
+    return ();
+}
+
+@external
+func test_verify_proof_invalid_proof{
+    syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashBuiltin*
+}() {
+    alloc_locals;
+
+    let (local peaks: felt*) = alloc();
+
+    let (node1) = hash2{hash_ptr=pedersen_ptr}(1, 1);
+    append(elem=1, peaks_len=0, peaks=peaks, tx_hash=181920);
+
+    assert peaks[0] = node1;
+    append(elem=2, peaks_len=1, peaks=peaks, tx_hash=181920);
+
+    let (node2) = hash2{hash_ptr=pedersen_ptr}(2, 2);
+    let (node3_1) = hash2{hash_ptr=pedersen_ptr}(node1, node2);
+    let (node3) = hash2{hash_ptr=pedersen_ptr}(3, node3_1);
+
+    let (local peaks: felt*) = alloc();
+    assert peaks[0] = node3;
+
+    let (local proof: felt*) = alloc();
+    assert proof[0] = node1;
+    %{ expect_revert() %}
+    verify_proof(1, 1, 1, proof, 1, peaks);
+
+    return ();
+}


### PR DESCRIPTION
- Upgrades protostar to v0.8.1
- Adds historical mmr: an MMR version that tracks all the root hashes in order to generate/verify proofs against any.
- Adds some unit tests revolving around this new feature.

This reduces the proof size but has the tradeoff of increasing the tree's contract storage consumption.